### PR TITLE
Fix: Address clippy warnings after Rust toolchain update.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c4-e5-chess"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Eugen Lindorfer"]
 edition = "2021"
 description = "C4-E5 Chess is a UCI compatible chess engine based on the move generator in crate Chess. These features are provided: Parallelised iterative depthening, late move pruning, principal variant search, transposition table."

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Eugen Lindorfer
+Copyright (c) 2024 Eugen Lindorfer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ These features are provided:
 At the time being, the focus was on simplicity and certainly there is a lot of potential in improvments in terms of playing strength.
 
 ## Documentation
-https://docs.rs/c4-e5-chess/0.2.2
+https://docs.rs/c4-e5-chess/0.2.3
 

--- a/src/engine/move_gen.rs
+++ b/src/engine/move_gen.rs
@@ -4,7 +4,6 @@ use chess::{Board, ChessMove, MoveGen, EMPTY};
 /// A trait to extend the move generator of crate Chess.
 pub trait MoveGenPrime {
     fn get_legal_sorted(board: &Board, old_move: Option<ChessMove>) -> Vec<AnnotatedMove>;
-    fn count_legal(board: &Board) -> usize;
 }
 
 impl MoveGenPrime for MoveGen {
@@ -20,7 +19,6 @@ impl MoveGenPrime for MoveGen {
             result.push(AnnotatedMove {
                 mv,
                 sc: 0,
-                capture: true,
                 node_count: 0,
             });
         }
@@ -30,7 +28,6 @@ impl MoveGenPrime for MoveGen {
             result.push(AnnotatedMove {
                 mv,
                 sc: 0,
-                capture: false,
                 node_count: 0,
             });
         }
@@ -44,10 +41,5 @@ impl MoveGenPrime for MoveGen {
             }
         }
         result
-    }
-
-    /// Calculate number of legal moves in given position.
-    fn count_legal(board: &Board) -> usize {
-        MoveGen::new_legal(board).count()
     }
 }

--- a/src/misc/types.rs
+++ b/src/misc/types.rs
@@ -12,5 +12,4 @@ pub struct AnnotatedMove {
     pub mv: ChessMove,
     pub sc: MoveScore,
     pub node_count: u64,
-    pub capture: bool,
 }


### PR DESCRIPTION
Small fixes.